### PR TITLE
Remove unnecessary variable assignment

### DIFF
--- a/com/williamfiset/datastructures/binarysearchtree/BinarySearchTree.java
+++ b/com/williamfiset/datastructures/binarysearchtree/BinarySearchTree.java
@@ -116,7 +116,6 @@ public class BinarySearchTree<T extends Comparable<T>> {
         Node rightChild = node.right;
 
         node.data = null;
-        node = null;
 
         return rightChild;
 
@@ -128,7 +127,6 @@ public class BinarySearchTree<T extends Comparable<T>> {
         Node leftChild = node.left;
 
         node.data = null;
-        node = null;
 
         return leftChild;
 


### PR DESCRIPTION
Since Java uses pass by value even if the object is a reference type, so when you set node = null here is gonna effect only in the local scope.