### PR TITLE
No unnecessary path compression

### DIFF
--- a/com/williamfiset/datastructures/unionfind/UnionFind.java
+++ b/com/williamfiset/datastructures/unionfind/UnionFind.java
@@ -44,7 +44,7 @@ public class UnionFind {
     // Compress the path leading back to the root.
     // Doing this operation is called "path compression"
     // and is what gives us amortized time complexity.
-    while (p != root) {
+    while (id[p] != root) {
       int next = id[p];
       id[p] = root;
       p = next;


### PR DESCRIPTION
Start path compression if parent is not root, since initial p is already under the root, It will avoid compression for already compressed paths